### PR TITLE
take a union of the bitmaps instead of least frequent bitmap

### DIFF
--- a/fluent/encoders/cio_encoder.py
+++ b/fluent/encoders/cio_encoder.py
@@ -124,7 +124,7 @@ class CioEncoder(LanguageEncoder):
         # Sample to remain sparse
         max_sparsity = int((self.targetSparsity / 100) * self.n)
         w = min(len(counts), max_sparsity)
-        position = [c[0] for c in counts.most_common(w)]
+        positions = [c[0] for c in counts.most_common(w)]
 
         # Populate encoding
         encoding = {

--- a/fluent/encoders/cio_encoder.py
+++ b/fluent/encoders/cio_encoder.py
@@ -19,12 +19,12 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-from collections import Counter
 import itertools
 import os
 import numpy
 import random
 
+from collections import Counter
 from cortipy.cortical_client import CorticalClient
 from cortipy.exceptions import UnsuccessfulEncodingError
 from fluent.encoders.language_encoder import LanguageEncoder

--- a/fluent/encoders/cio_encoder.py
+++ b/fluent/encoders/cio_encoder.py
@@ -100,7 +100,7 @@ class CioEncoder(LanguageEncoder):
     return [((term["term"], term["score"])) for term in terms]
 
 
-  def _subEncoding(self, text):
+  def _subEncoding(self, text, method="df"):
     """
     @param text             (str)             A non-tokenized sample of text.
     @return encoding        (dict)            Fingerprint from cortipy client.
@@ -110,28 +110,35 @@ class CioEncoder(LanguageEncoder):
     tokens = list(itertools.chain.from_iterable(
       [t.split(',') for t in self.client.tokenize(text)]))
     try:
-      # Take a union of the bitmaps
-      union = numpy.zeros(0)
-      for t in tokens:
-        bitmap = self.client.getBitmap(t)["fingerprint"]["positions"]
-        union = numpy.union1d(bitmap, union)
+      if method == "df":
+        encoding = min([self.client.getBitmap(t) for t in tokens],
+                        key=lambda x: x["df"])
+      elif method == "keyword":
+        # Take a union of the bitmaps
+        union = numpy.zeros(0)
+        for t in tokens:
+          bitmap = self.client.getBitmap(t)["fingerprint"]["positions"]
+          union = numpy.union1d(bitmap, union)
 
-      # Sample to remain sparse
-      count = len(union)
-      sparsity = int((self.targetSparsity / 100) * self.n)
-      sampleIndices = random.sample(xrange(count), min(count, sparsity))
+        # Sample to remain sparse
+        count = len(union)
+        sparsity = int((self.targetSparsity / 100) * self.n)
+        sampleIndices = random.sample(xrange(count), min(count, sparsity))
 
-      # Populate encoding
-      encoding = {}
-      encoding["text"] = text
-      encoding["sparsity"] = min(sparsity, count) * 100 / float(self.n)
-      encoding["df"] = 0.0
-      encoding["height"] = self.h
-      encoding["width"] = self.w
-      encoding["score"] = 0.0
-      encoding["fingerprint"] = {}
-      encoding["fingerprint"]["positions"] = numpy.sort(union[sampleIndices]).tolist()
-      encoding["pos_types"] = []
+        # Populate encoding
+        encoding = {}
+        encoding["text"] = text
+        encoding["sparsity"] = min(sparsity, count) * 100 / float(self.n)
+        encoding["df"] = 0.0
+        encoding["height"] = self.h
+        encoding["width"] = self.w
+        encoding["score"] = 0.0
+        encoding["fingerprint"] = {}
+        positions = union[sampleIndices]
+        encoding["fingerprint"]["positions"] = numpy.sort(positions).tolist()
+        encoding["pos_types"] = []
+      else:
+        raise TypeError("method must be either \'df\' or \'keyword\'")
     except UnsuccessfulEncodingError:
       if self.verbosity > 0:
         print ("\tThe client returned no substitute encoding for the text "

--- a/fluent/encoders/cio_encoder.py
+++ b/fluent/encoders/cio_encoder.py
@@ -20,8 +20,8 @@
 # ----------------------------------------------------------------------
 
 import itertools
-import os
 import numpy
+import os
 import random
 
 from collections import Counter
@@ -135,12 +135,12 @@ class CioEncoder(LanguageEncoder):
             "width": self.w,
             "score": 0.0,
             "fingerprint": {
-              "position":sorted(position)
+              "positions":sorted(positions)
               },
             "pos_types": []
             }
       else:
-        raise TypeError("method must be either \'df\' or \'keyword\'")
+        raise ValueError("method must be either \'df\' or \'keyword\'")
     except UnsuccessfulEncodingError:
       if self.verbosity > 0:
         print ("\tThe client returned no substitute encoding for the text "


### PR DESCRIPTION
When there is an unsuccessful encoding, take a union of the bitmaps for the tokens instead of the bitmap of the least frequent token.

@BoltzmannBrain 