### PR TITLE
Return winners from descending order for certain distance metrics

### DIFF
--- a/fluent/models/classify_endpoint.py
+++ b/fluent/models/classify_endpoint.py
@@ -143,7 +143,12 @@ class ClassificationModelEndpoint(ClassificationModel):
     Return indices of winning categories, based off of the input metric.
     Overrides the base class implementation.
     """
+    descendingOrder = set(["overlappingAll", "overlappingLeftRight",
+      "overlappingRightLeft", "cosineSimilarity"])
     metricValues = numpy.array([v[metric] for v in distances.values()])
     sortedIdx = numpy.argsort(metricValues)
+
+    if metric in descendingOrder:
+      sortedIdx = sortedIdx[::-1]
 
     return [distances.keys()[catIdx] for catIdx in sortedIdx[:numberCats]]

--- a/fluent/models/classify_endpoint.py
+++ b/fluent/models/classify_endpoint.py
@@ -144,7 +144,7 @@ class ClassificationModelEndpoint(ClassificationModel):
     Overrides the base class implementation.
     """
     descendingOrder = set(["overlappingAll", "overlappingLeftRight",
-      "overlappingRightLeft", "cosineSimilarity"])
+      "overlappingRightLeft", "cosineSimilarity", "weightedScoring"])
     metricValues = numpy.array([v[metric] for v in distances.values()])
     sortedIdx = numpy.argsort(metricValues)
 

--- a/fluent/models/classify_endpoint.py
+++ b/fluent/models/classify_endpoint.py
@@ -143,11 +143,12 @@ class ClassificationModelEndpoint(ClassificationModel):
     Return indices of winning categories, based off of the input metric.
     Overrides the base class implementation.
     """
-    descendingOrder = set(["overlappingAll", "overlappingLeftRight",
-      "overlappingRightLeft", "cosineSimilarity", "weightedScoring"])
     metricValues = numpy.array([v[metric] for v in distances.values()])
     sortedIdx = numpy.argsort(metricValues)
 
+    # euclideanDistance and jaccardDistance are ascending
+    descendingOrder = set(["overlappingAll", "overlappingLeftRight",
+      "overlappingRightLeft", "cosineSimilarity", "weightedScoring"])
     if metric in descendingOrder:
       sortedIdx = sortedIdx[::-1]
 


### PR DESCRIPTION
Modified winningLabels to return the largest winners for "overlappingAll", "overlappingLeftRight", "overlappingRightLeft", "cosineSimilarity", and "weightedScoring".  Still returns the smallest values for the other metrics.

@BoltzmannBrain 