### PR TITLE
Models now use raw overlap as the distance metric for KNN

### DIFF
--- a/fluent/models/classify_fingerprint.py
+++ b/fluent/models/classify_fingerprint.py
@@ -41,7 +41,8 @@ class ClassificationModelFingerprint(ClassificationModel):
 
     # Init kNN classifier and Cortical.io encoder; need valid API key (see
     # CioEncoder init for details).
-    self.classifier = KNNClassifier(k=1, exact=False, verbosity=verbosity-1)
+    self.classifier = KNNClassifier(k=1, exact=False, verbosity=verbosity-1,
+      distanceMethod="rawOverlap")
     self.encoder = CioEncoder(cacheDir="./experiments/cache")
     self.n = self.encoder.n
     self.w = int((self.encoder.targetSparsity/100)*self.n)

--- a/fluent/models/classify_random_sdr.py
+++ b/fluent/models/classify_random_sdr.py
@@ -49,7 +49,8 @@ class ClassificationModelRandomSDR(ClassificationModel):
     #   specify 'distanceMethod'='rawOverlap' for overlap; Euclidean is std.
     #   verbosity=1 for debugging
     #   standard k is 1
-    self.classifier = KNNClassifier(exact=True, verbosity=verbosity-1)
+    self.classifier = KNNClassifier(exact=True, verbosity=verbosity-1,
+      distanceMethod="rawOverlap")
 
 
   def encodePattern(self, sample):


### PR DESCRIPTION
Modified fingerprint and random sdr models to use raw overlap as the distance metric for KNN.

Fixes #88 

@BoltzmannBrain 